### PR TITLE
Finalized the vision code

### DIFF
--- a/include/imagePipeline.h
+++ b/include/imagePipeline.h
@@ -26,6 +26,12 @@ class ImagePipeline {
         uint8_t skyVal = 178; // RGB value of the skybox
         const uint8_t removeVal = 0; // Value used to overwrite pixels we don't care for
 
+        // Checks if the lines plotted by the four corners don't intersect
+        bool checkTangledBox(std::vector<cv::Point2f> corners);
+
+        // See if the test point lies above the line between points A and B
+        bool checkAbove(cv::Point2f test, cv::Point2f a, cv::Point2f b);
+
         // Used to produce an output of the reference image in the scene based on existing matches and points
         cv::Mat drawSceneMatches(cv::Mat &scene, cv::Mat &refImage, std::vector<cv::DMatch> &matches, 
             std::vector<cv::KeyPoint> &keyPointsRef, std::vector<cv::KeyPoint> &keyPointsScene);

--- a/src/contest2.cpp
+++ b/src/contest2.cpp
@@ -107,7 +107,7 @@ int main(int argc, char** argv) {
         // Test parameters
         std::string testFileFolder = "/home/brobot/catkin_ws/src/mie443_contest2/testpics/";
         bool printInnerWorks = true;
-        std::string searchTerm = "kang";
+        std::string searchTerm = "pepper";
         // Leave as "" for all files in folder (not recommended since too many consecutive searches results in errors)
 
         // Load in all test files

--- a/src/contest2.cpp
+++ b/src/contest2.cpp
@@ -107,7 +107,7 @@ int main(int argc, char** argv) {
         // Test parameters
         std::string testFileFolder = "/home/brobot/catkin_ws/src/mie443_contest2/testpics/";
         bool printInnerWorks = true;
-        std::string searchTerm = "pepper";
+        std::string searchTerm = "spot";
         // Leave as "" for all files in folder (not recommended since too many consecutive searches results in errors)
 
         // Load in all test files

--- a/src/imagePipeline.cpp
+++ b/src/imagePipeline.cpp
@@ -84,7 +84,6 @@ int ImagePipeline::getTemplateID(Boxes& boxes, bool showInternals) {
 
     // Convert image from RGB to greyscale space
     cv::cvtColor(img, img, cv::COLOR_RGBA2GRAY, 0);
-    const Mat imgBackup = img; // Used as a backup for the preprocessed input so additional changes can be done to it case by case
 
     //cv::imshow("Processed view. Press any key to continue.", img);
 
@@ -107,7 +106,6 @@ int ImagePipeline::getTemplateID(Boxes& boxes, bool showInternals) {
     Mat bestTag; // Stores the best matched tag for display purposes
 
     for (int tagID = 0; tagID < boxes.templates.size(); tagID++) {
-        img = imgBackup.clone(); // Restore original preprocessed image
 
         // File for current tag check
         Mat tagImage = boxes.templates[tagID];

--- a/src/imagePipeline.cpp
+++ b/src/imagePipeline.cpp
@@ -101,16 +101,24 @@ int ImagePipeline::getTemplateID(Boxes& boxes, bool showInternals) {
     }
 
     float confidence[boxes.templates.size()];
-    for (int tagID = 0; tagID < boxes.templates.size(); tagID++) {
+    for (int tagID = 11; tagID < boxes.templates.size(); tagID++) {
+        img = imgBackup.clone(); // Restore original preprocessed image
+
         // File for current tag check
-        Mat tagImageRaw = boxes.templates[tagID];
-        Mat tagImage = tagImageRaw;
+        Mat tagImage = boxes.templates[tagID];
 
         if (tagID == 11) {
             // Handle pepper
+            double brightness = -100.0;
+            resize(tagImage,tagImage, Size(500,400));
+            tagImage.convertTo(tagImage, -1, 1, brightness);
+            //tagImage = tagImage.clone();
+
+            cv::imshow("Processed tag. Press any key to continue.", tagImage);
+            cv::waitKey(500);
         }
 
-        GaussianBlur(tagImageRaw, tagImage, Size( 3, 3), 0, 0); // Add blur to aid feature matching
+        GaussianBlur(tagImage, tagImage, Size( 3, 3), 0, 0); // Add blur to aid feature matching
         //cv::imshow("Tag as used", tagImage);
 
         std::vector<DMatch> goodMatches;

--- a/src/imagePipeline.cpp
+++ b/src/imagePipeline.cpp
@@ -84,10 +84,11 @@ int ImagePipeline::getTemplateID(Boxes& boxes, bool showInternals) {
 
     // Convert image from RGB to greyscale space
     cv::cvtColor(img, img, cv::COLOR_RGBA2GRAY, 0);
+    const Mat imgBackup = img; // Used as a backup for the preprocessed input so additional changes can be done to it case by case
 
     //cv::imshow("Processed view. Press any key to continue.", img);
 
-    //-- Step 1: Detect the keypoints using SURF Detector, compute the descriptors
+    // Detect the keypoints using SURF Detector, compute the descriptors
     Ptr<SURF> detector = SURF::create( minHessian ); // Defined in header
     std::vector<KeyPoint> keyPointsObject, keyPointsScene;
     Mat descriptorsScene;

--- a/src/imagePipeline.cpp
+++ b/src/imagePipeline.cpp
@@ -111,14 +111,7 @@ int ImagePipeline::getTemplateID(Boxes& boxes, bool showInternals) {
 
         // File for current tag check
         Mat tagImage = boxes.templates[tagID];
-
-        if (tagID == 11) {
-            // Handle pepper
-            double brightness = -100.0;
-            resize(tagImage,tagImage, Size(500,400));
-            tagImage.convertTo(tagImage, -1, 1, brightness);
-            //tagImage = tagImage.clone();
-        }
+        resize(tagImage,tagImage, Size(500,400)); // Resize to match map aspect ratio
 
         GaussianBlur(tagImage, tagImage, Size( 3, 3), 0, 0); // Add blur to aid feature matching
         //cv::imshow("Tag as used", tagImage);

--- a/src/imagePipeline.cpp
+++ b/src/imagePipeline.cpp
@@ -105,6 +105,10 @@ int ImagePipeline::getTemplateID(Boxes& boxes, bool showInternals) {
         Mat tagImageRaw = boxes.templates[tagID];
         Mat tagImage = tagImageRaw;
 
+        if (tagID == 11) {
+            // Handle pepper
+        }
+
         GaussianBlur(tagImageRaw, tagImage, Size( 3, 3), 0, 0); // Add blur to aid feature matching
         //cv::imshow("Tag as used", tagImage);
 

--- a/src/imagePipeline.cpp
+++ b/src/imagePipeline.cpp
@@ -141,13 +141,8 @@ int ImagePipeline::getTemplateID(Boxes& boxes, bool showInternals) {
             // Check if there is a possible transform
             if (H.empty()) {
                 // Failed to find a transform from reference to scene
-
                 ROS_WARN("Unable to transform perspective using reference %d.", tagID + 1);
-                confidence = 0;
-
-                // Code to try and interate until resolved
-                //tagID--; 
-                //continue;
+                confidence = 0; // It's a bad match
             }
             else {
                 // Tranform from refence image to scene is possible


### PR DESCRIPTION
Addressed most issues in initial version of vision code, namely identifying Pepper/Polly/Pauline/Poppy/Patricia... This was achieved by simply resizing the reference image to the 5:4 aspect ratio of the blocks in the world. I specifically used 500x400 pixels for this purpose since it is also roughly the average size of the object in the scene view when we are trying to scan. 

Added code to check if the determined boundary box for an object was self-intersecting as well and that seems to have helped cut down on bad readings.

Repeated all test cases a few times over with this, there were no more false positives! Overall the performance of the system improved, leaving a few hard test cases that we are unable to determine what is present.
- Cases that the rover is too misaligned with the normal to detect objects 
  - kangr6
  - kangr7
  - pup1
- Cases where there are two similarly dominant objects, so no choice is made
  - tort3

Overall I think it is safe to say that our vision code is complete and ready for the contest.